### PR TITLE
Import pending patches to fix driver build on kernel 6.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /*/*
 !/*/PKGBUILD
+!/*/*.patch

--- a/intel-ipu6-dkms-git/0001-Fix-compilation-with-kernel-6.1.patch
+++ b/intel-ipu6-dkms-git/0001-Fix-compilation-with-kernel-6.1.patch
@@ -1,0 +1,365 @@
+From 6f4d2f538907c03de68279cd2c2edcb2c551aa15 Mon Sep 17 00:00:00 2001
+From: Hans de Goede <hdegoede@redhat.com>
+Date: Mon, 21 Nov 2022 16:44:50 +0100
+Subject: [PATCH 1/2] Fix compilation with kernel 6.1
+
+Fix compilation with kernel 6.1, deal with the media-controller
+changes which have landed in 6.1-rc2.
+
+Closes: #63
+
+Signed-off-by: Hans de Goede <hdegoede@redhat.com>
+---
+ .../media/pci/intel/ipu-isys-csi2-be-soc.c    |  3 +-
+ drivers/media/pci/intel/ipu-isys-csi2.c       | 24 +++++---
+ drivers/media/pci/intel/ipu-isys-queue.c      | 19 +++---
+ drivers/media/pci/intel/ipu-isys-subdev.c     |  3 +-
+ drivers/media/pci/intel/ipu-isys-video.c      | 59 +++++++++++++------
+ drivers/media/pci/intel/ipu.h                 |  9 +++
+ drivers/media/pci/intel/ipu6/ipu6-isys-csi2.c |  3 +-
+ 7 files changed, 82 insertions(+), 38 deletions(-)
+
+diff --git a/drivers/media/pci/intel/ipu-isys-csi2-be-soc.c b/drivers/media/pci/intel/ipu-isys-csi2-be-soc.c
+index 3ba87107b..de6381448 100644
+--- a/drivers/media/pci/intel/ipu-isys-csi2-be-soc.c
++++ b/drivers/media/pci/intel/ipu-isys-csi2-be-soc.c
+@@ -106,7 +106,8 @@ __subdev_link_validate(struct v4l2_subdev *sd, struct media_link *link,
+ 		       struct v4l2_subdev_format *source_fmt,
+ 		       struct v4l2_subdev_format *sink_fmt)
+ {
+-	struct ipu_isys_pipeline *ip = container_of(sd->entity.pipe,
++	struct media_pipeline *media_pipe = media_entity_pipeline(&sd->entity);
++	struct ipu_isys_pipeline *ip = container_of(media_pipe,
+ 						    struct ipu_isys_pipeline,
+ 						    pipe);
+ 
+diff --git a/drivers/media/pci/intel/ipu-isys-csi2.c b/drivers/media/pci/intel/ipu-isys-csi2.c
+index 0bd7a1036..ca4bbf11b 100644
+--- a/drivers/media/pci/intel/ipu-isys-csi2.c
++++ b/drivers/media/pci/intel/ipu-isys-csi2.c
+@@ -76,7 +76,9 @@ static struct v4l2_subdev_internal_ops csi2_sd_internal_ops = {
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
+ int ipu_isys_csi2_get_link_freq(struct ipu_isys_csi2 *csi2, s64 *link_freq)
+ {
+-	struct ipu_isys_pipeline *pipe = container_of(csi2->asd.sd.entity.pipe,
++	struct media_pipeline *media_pipe =
++		media_entity_pipeline(&csi2->asd.sd.entity);
++	struct ipu_isys_pipeline *pipe = container_of(media_pipe,
+ 						      struct ipu_isys_pipeline,
+ 						      pipe);
+ 	struct v4l2_subdev *ext_sd =
+@@ -256,8 +258,9 @@ ipu_isys_csi2_calc_timing(struct ipu_isys_csi2 *csi2,
+ 
+ static int set_stream(struct v4l2_subdev *sd, int enable)
+ {
++	struct media_pipeline *media_pipe = media_entity_pipeline(&sd->entity);
+ 	struct ipu_isys_csi2 *csi2 = to_ipu_isys_csi2(sd);
+-	struct ipu_isys_pipeline *ip = container_of(sd->entity.pipe,
++	struct ipu_isys_pipeline *ip = container_of(media_pipe,
+ 						    struct ipu_isys_pipeline,
+ 						    pipe);
+ 	struct ipu_isys_csi2_config *cfg;
+@@ -315,21 +318,23 @@ static void csi2_capture_done(struct ipu_isys_pipeline *ip,
+ 
+ static int csi2_link_validate(struct media_link *link)
+ {
++	struct media_pipeline *media_pipe;
+ 	struct ipu_isys_csi2 *csi2;
+ 	struct ipu_isys_pipeline *ip;
+ 	int rval;
+ 
+-	if (!link->sink->entity ||
+-	    !link->sink->entity->pipe || !link->source->entity)
++	if (!link->sink->entity || !link->source->entity)
+ 		return -EINVAL;
+ 	csi2 =
+ 	    to_ipu_isys_csi2(media_entity_to_v4l2_subdev(link->sink->entity));
+-	ip = to_ipu_isys_pipeline(link->sink->entity->pipe);
++	media_pipe = media_entity_pipeline(link->sink->entity);
++	if (!media_pipe)
++		return -EINVAL;
++
++	ip = to_ipu_isys_pipeline(media_pipe);
+ 	csi2->receiver_errors = 0;
+ 	ip->csi2 = csi2;
+-	ipu_isys_video_add_capture_done(to_ipu_isys_pipeline
+-					(link->sink->entity->pipe),
+-					csi2_capture_done);
++	ipu_isys_video_add_capture_done(ip, csi2_capture_done);
+ 
+ 	rval = v4l2_subdev_link_validate(link);
+ 	if (rval)
+@@ -396,7 +401,8 @@ static int __subdev_link_validate(struct v4l2_subdev *sd,
+ 				  struct v4l2_subdev_format *source_fmt,
+ 				  struct v4l2_subdev_format *sink_fmt)
+ {
+-	struct ipu_isys_pipeline *ip = container_of(sd->entity.pipe,
++	struct media_pipeline *media_pipe = media_entity_pipeline(&sd->entity);
++	struct ipu_isys_pipeline *ip = container_of(media_pipe,
+ 						    struct ipu_isys_pipeline,
+ 						    pipe);
+ 
+diff --git a/drivers/media/pci/intel/ipu-isys-queue.c b/drivers/media/pci/intel/ipu-isys-queue.c
+index c0ff47a3f..a4deef08c 100644
+--- a/drivers/media/pci/intel/ipu-isys-queue.c
++++ b/drivers/media/pci/intel/ipu-isys-queue.c
+@@ -532,8 +532,9 @@ static void __buf_queue(struct vb2_buffer *vb, bool force)
+ 	struct ipu_isys_queue *aq = vb2_queue_to_ipu_isys_queue(vb->vb2_queue);
+ 	struct ipu_isys_video *av = ipu_isys_queue_to_video(aq);
+ 	struct ipu_isys_buffer *ib = vb2_buffer_to_ipu_isys_buffer(vb);
+-	struct ipu_isys_pipeline *ip =
+-	    to_ipu_isys_pipeline(av->vdev.entity.pipe);
++	struct media_pipeline *media_pipe =
++		media_entity_pipeline(&av->vdev.entity);
++	struct ipu_isys_pipeline *ip = to_ipu_isys_pipeline(media_pipe);
+ 	struct ipu_isys_buffer_list bl;
+ 
+ 	struct ipu_fw_isys_frame_buff_set_abi *buf = NULL;
+@@ -789,7 +790,7 @@ static int start_streaming(struct vb2_queue *q, unsigned int count)
+ 
+ 	mutex_lock(&av->isys->stream_mutex);
+ 
+-	first = !av->vdev.entity.pipe;
++	first = !media_entity_pipeline(&av->vdev.entity);
+ 
+ 	if (first) {
+ 		rval = ipu_isys_video_prepare_streaming(av, 1);
+@@ -807,7 +808,7 @@ static int start_streaming(struct vb2_queue *q, unsigned int count)
+ 		goto out_unprepare_streaming;
+ 	}
+ 
+-	ip = to_ipu_isys_pipeline(av->vdev.entity.pipe);
++	ip = to_ipu_isys_pipeline(media_entity_pipeline(&av->vdev.entity));
+ 	pipe_av = container_of(ip, struct ipu_isys_video, ip);
+ 	mutex_unlock(&av->mutex);
+ 
+@@ -863,8 +864,9 @@ static void stop_streaming(struct vb2_queue *q)
+ {
+ 	struct ipu_isys_queue *aq = vb2_queue_to_ipu_isys_queue(q);
+ 	struct ipu_isys_video *av = ipu_isys_queue_to_video(aq);
+-	struct ipu_isys_pipeline *ip =
+-	    to_ipu_isys_pipeline(av->vdev.entity.pipe);
++	struct media_pipeline *media_pipe =
++		media_entity_pipeline(&av->vdev.entity);
++	struct ipu_isys_pipeline *ip = to_ipu_isys_pipeline(media_pipe);
+ 	struct ipu_isys_video *pipe_av =
+ 	    container_of(ip, struct ipu_isys_video, ip);
+ 
+@@ -956,8 +958,9 @@ ipu_isys_buf_calc_sequence_time(struct ipu_isys_buffer *ib,
+ 	struct ipu_isys_queue *aq = vb2_queue_to_ipu_isys_queue(vb->vb2_queue);
+ 	struct ipu_isys_video *av = ipu_isys_queue_to_video(aq);
+ 	struct device *dev = &av->isys->adev->dev;
+-	struct ipu_isys_pipeline *ip =
+-	    to_ipu_isys_pipeline(av->vdev.entity.pipe);
++	struct media_pipeline *media_pipe =
++		media_entity_pipeline(&av->vdev.entity);
++	struct ipu_isys_pipeline *ip = to_ipu_isys_pipeline(media_pipe);
+ 	u64 ns;
+ 	u32 sequence;
+ 
+diff --git a/drivers/media/pci/intel/ipu-isys-subdev.c b/drivers/media/pci/intel/ipu-isys-subdev.c
+index fdaa6e14c..90863852f 100644
+--- a/drivers/media/pci/intel/ipu-isys-subdev.c
++++ b/drivers/media/pci/intel/ipu-isys-subdev.c
+@@ -693,7 +693,8 @@ int ipu_isys_subdev_link_validate(struct v4l2_subdev *sd,
+ {
+ 	struct v4l2_subdev *source_sd =
+ 	    media_entity_to_v4l2_subdev(link->source->entity);
+-	struct ipu_isys_pipeline *ip = container_of(sd->entity.pipe,
++	struct media_pipeline *media_pipe = media_entity_pipeline(&sd->entity);
++	struct ipu_isys_pipeline *ip = container_of(media_pipe,
+ 						    struct ipu_isys_pipeline,
+ 						    pipe);
+ 	struct ipu_isys_subdev *asd = to_ipu_isys_subdev(sd);
+diff --git a/drivers/media/pci/intel/ipu-isys-video.c b/drivers/media/pci/intel/ipu-isys-video.c
+index 0c99e1459..9aefd5e31 100644
+--- a/drivers/media/pci/intel/ipu-isys-video.c
++++ b/drivers/media/pci/intel/ipu-isys-video.c
+@@ -602,8 +602,7 @@ static int link_validate(struct media_link *link)
+ 	struct ipu_isys_video *av =
+ 	    container_of(link->sink, struct ipu_isys_video, pad);
+ 	/* All sub-devices connected to a video node are ours. */
+-	struct ipu_isys_pipeline *ip =
+-		to_ipu_isys_pipeline(av->vdev.entity.pipe);
++	struct ipu_isys_pipeline *ip = &av->ip;
+ 	struct v4l2_subdev *sd;
+ 
+ 	if (!link->source->entity)
+@@ -645,8 +644,9 @@ static void put_stream_opened(struct ipu_isys_video *av)
+ 
+ static int get_stream_handle(struct ipu_isys_video *av)
+ {
+-	struct ipu_isys_pipeline *ip =
+-	    to_ipu_isys_pipeline(av->vdev.entity.pipe);
++	struct media_pipeline *media_pipe =
++		media_entity_pipeline(&av->vdev.entity);
++	struct ipu_isys_pipeline *ip = to_ipu_isys_pipeline(media_pipe);
+ 	unsigned int stream_handle;
+ 	unsigned long flags;
+ 
+@@ -667,8 +667,9 @@ static int get_stream_handle(struct ipu_isys_video *av)
+ 
+ static void put_stream_handle(struct ipu_isys_video *av)
+ {
+-	struct ipu_isys_pipeline *ip =
+-	    to_ipu_isys_pipeline(av->vdev.entity.pipe);
++	struct media_pipeline *media_pipe =
++		media_entity_pipeline(&av->vdev.entity);
++	struct ipu_isys_pipeline *ip = to_ipu_isys_pipeline(media_pipe);
+ 	unsigned long flags;
+ 
+ 	spin_lock_irqsave(&av->isys->lock, flags);
+@@ -883,8 +884,9 @@ void
+ ipu_isys_prepare_fw_cfg_default(struct ipu_isys_video *av,
+ 				struct ipu_fw_isys_stream_cfg_data_abi *cfg)
+ {
+-	struct ipu_isys_pipeline *ip =
+-	    to_ipu_isys_pipeline(av->vdev.entity.pipe);
++	struct media_pipeline *media_pipe =
++		media_entity_pipeline(&av->vdev.entity);
++	struct ipu_isys_pipeline *ip = to_ipu_isys_pipeline(media_pipe);
+ 	struct ipu_isys_queue *aq = &av->aq;
+ 	struct ipu_fw_isys_output_pin_info_abi *pin_info;
+ 	struct ipu_isys *isys = av->isys;
+@@ -1036,8 +1038,9 @@ static unsigned int get_comp_format(u32 code)
+ static int start_stream_firmware(struct ipu_isys_video *av,
+ 				 struct ipu_isys_buffer_list *bl)
+ {
+-	struct ipu_isys_pipeline *ip =
+-	    to_ipu_isys_pipeline(av->vdev.entity.pipe);
++	struct media_pipeline *media_pipe =
++		media_entity_pipeline(&av->vdev.entity);
++	struct ipu_isys_pipeline *ip = to_ipu_isys_pipeline(media_pipe);
+ 	struct device *dev = &av->isys->adev->dev;
+ 	struct v4l2_subdev_selection sel_fmt = {
+ 		.which = V4L2_SUBDEV_FORMAT_ACTIVE,
+@@ -1275,8 +1278,9 @@ out_put_stream_handle:
+ 
+ static void stop_streaming_firmware(struct ipu_isys_video *av)
+ {
+-	struct ipu_isys_pipeline *ip =
+-	    to_ipu_isys_pipeline(av->vdev.entity.pipe);
++	struct media_pipeline *media_pipe =
++		media_entity_pipeline(&av->vdev.entity);
++	struct ipu_isys_pipeline *ip = to_ipu_isys_pipeline(media_pipe);
+ 	struct device *dev = &av->isys->adev->dev;
+ 	int rval, tout;
+ 	enum ipu_fw_isys_send_type send_type =
+@@ -1304,8 +1308,9 @@ static void stop_streaming_firmware(struct ipu_isys_video *av)
+ 
+ static void close_streaming_firmware(struct ipu_isys_video *av)
+ {
+-	struct ipu_isys_pipeline *ip =
+-	    to_ipu_isys_pipeline(av->vdev.entity.pipe);
++	struct media_pipeline *media_pipe =
++		media_entity_pipeline(&av->vdev.entity);
++	struct ipu_isys_pipeline *ip = to_ipu_isys_pipeline(media_pipe);
+ 	struct device *dev = &av->isys->adev->dev;
+ 	int rval, tout;
+ 
+@@ -1376,12 +1381,19 @@ int ipu_isys_video_prepare_streaming(struct ipu_isys_video *av,
+ 	dev_dbg(dev, "prepare stream: %d\n", state);
+ 
+ 	if (!state) {
+-		ip = to_ipu_isys_pipeline(av->vdev.entity.pipe);
++		struct media_pipeline *media_pipe =
++			media_entity_pipeline(&av->vdev.entity);
++
++		ip = to_ipu_isys_pipeline(media_pipe);
+ 
+ 		if (ip->interlaced && isys->short_packet_source ==
+ 		    IPU_ISYS_SHORT_PACKET_FROM_RECEIVER)
+ 			short_packet_queue_destroy(ip);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
++		media_pipeline_stop(av->vdev.entity.pads);
++#else
+ 		media_pipeline_stop(&av->vdev.entity);
++#endif
+ 		media_entity_enum_cleanup(&ip->entity_enum);
+ 		return 0;
+ 	}
+@@ -1410,7 +1422,11 @@ int ipu_isys_video_prepare_streaming(struct ipu_isys_video *av,
+ 	if (rval)
+ 		return rval;
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
++	rval = media_pipeline_start(av->vdev.entity.pads, &ip->pipe);
++#else
+ 	rval = media_pipeline_start(&av->vdev.entity, &ip->pipe);
++#endif
+ 	if (rval < 0) {
+ 		dev_dbg(dev, "pipeline start failed\n");
+ 		goto out_enum_cleanup;
+@@ -1451,7 +1467,11 @@ int ipu_isys_video_prepare_streaming(struct ipu_isys_video *av,
+ 	return 0;
+ 
+ out_pipeline_stop:
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
++	media_pipeline_stop(av->vdev.entity.pads);
++#else
+ 	media_pipeline_stop(&av->vdev.entity);
++#endif
+ 
+ out_enum_cleanup:
+ 	media_entity_enum_cleanup(&ip->entity_enum);
+@@ -1470,8 +1490,10 @@ static void configure_stream_watermark(struct ipu_isys_video *av)
+ 	struct isys_iwake_watermark *iwake_watermark;
+ 	struct v4l2_control vb = { .id = V4L2_CID_VBLANK, .value = 0 };
+ 	struct v4l2_control hb = { .id = V4L2_CID_HBLANK, .value = 0 };
++	struct media_pipeline *media_pipe =
++		media_entity_pipeline(&av->vdev.entity);
+ 
+-	ip = to_ipu_isys_pipeline(av->vdev.entity.pipe);
++	ip = to_ipu_isys_pipeline(media_pipe);
+ 	if (!ip->external->entity) {
+ 		WARN_ON(1);
+ 		return;
+@@ -1578,8 +1600,9 @@ int ipu_isys_video_set_streaming(struct ipu_isys_video *av,
+ 	struct media_entity_enum entities;
+ 
+ 	struct media_entity *entity, *entity2;
+-	struct ipu_isys_pipeline *ip =
+-	    to_ipu_isys_pipeline(av->vdev.entity.pipe);
++	struct media_pipeline *media_pipe =
++		media_entity_pipeline(&av->vdev.entity);
++	struct ipu_isys_pipeline *ip = to_ipu_isys_pipeline(media_pipe);
+ 	struct v4l2_subdev *sd, *esd;
+ 	int rval = 0;
+ 
+diff --git a/drivers/media/pci/intel/ipu.h b/drivers/media/pci/intel/ipu.h
+index 17c178fcf..127680a3e 100644
+--- a/drivers/media/pci/intel/ipu.h
++++ b/drivers/media/pci/intel/ipu.h
+@@ -109,4 +109,13 @@ int request_cpd_fw(const struct firmware **firmware_p, const char *name,
+ extern enum ipu_version ipu_ver;
+ void ipu_internal_pdata_init(void);
+ 
++/* Helpers for building against various kernel versions */
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
++#include <media/media-entity.h>
++static inline struct media_pipeline *media_entity_pipeline(struct media_entity *entity)
++{
++       return entity->pipe;
++}
++#endif
++
+ #endif /* IPU_H */
+diff --git a/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.c b/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.c
+index c07a28e90..9ff76ed89 100644
+--- a/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.c
++++ b/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.c
+@@ -450,9 +450,10 @@ int ipu_isys_csi2_set_stream(struct v4l2_subdev *sd,
+ 			     struct ipu_isys_csi2_timing timing,
+ 			     unsigned int nlanes, int enable)
+ {
++	struct media_pipeline *media_pipe = media_entity_pipeline(&sd->entity);
+ 	struct ipu_isys_csi2 *csi2 = to_ipu_isys_csi2(sd);
+ 	struct ipu_isys *isys = csi2->isys;
+-	struct ipu_isys_pipeline *ip = container_of(sd->entity.pipe,
++	struct ipu_isys_pipeline *ip = container_of(media_pipe,
+ 						    struct ipu_isys_pipeline,
+ 						    pipe);
+ 	struct ipu_isys_csi2_config *cfg =
+-- 
+2.39.0
+

--- a/intel-ipu6-dkms-git/0002-ipu-isys-queue-Fix-NULL-pointer-deref-with-kernels-6.patch
+++ b/intel-ipu6-dkms-git/0002-ipu-isys-queue-Fix-NULL-pointer-deref-with-kernels-6.patch
@@ -1,0 +1,40 @@
+From a6ef9d94a82cfa5b1c0dd732a987cd45654579e6 Mon Sep 17 00:00:00 2001
+From: Hans de Goede <hdegoede@redhat.com>
+Date: Wed, 7 Dec 2022 21:26:02 +0100
+Subject: [PATCH 2/2] ipu-isys-queue: Fix NULL pointer deref with kernels >=
+ 6.2
+
+Kernel >= 6.2 set vb2_queue->streaming a bit earlier as <= 6.1,
+specifically vb2_queue->streaming is set before the videobuf2-core
+enqueues the buffers (just before calling start_streaming).
+
+__buf_queue() uses vb2_queue->streaming to differentiate between
+buffers queued before and after start_streaming has been called and
+that will now no longer work, leading to a NULL pointer deref of
+the not yet setup media_pipe pointer.
+
+Fix this by explicitly checking for media_pipe == NULL. Note this
+check cannot be used to replace the vb2_queue->streaming check since
+for kernels < 6.1 media_pipe is always set.
+
+Signed-off-by: Hans de Goede <hdegoede@redhat.com>
+---
+ drivers/media/pci/intel/ipu-isys-queue.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/media/pci/intel/ipu-isys-queue.c b/drivers/media/pci/intel/ipu-isys-queue.c
+index a4deef08c..4fd7c32ca 100644
+--- a/drivers/media/pci/intel/ipu-isys-queue.c
++++ b/drivers/media/pci/intel/ipu-isys-queue.c
+@@ -566,7 +566,7 @@ static void __buf_queue(struct vb2_buffer *vb, bool force)
+ 	if (ib->req)
+ 		return;
+ 
+-	if (!pipe_av || !vb->vb2_queue->streaming) {
++	if (!pipe_av || !media_pipe || !vb->vb2_queue->streaming) {
+ 		dev_dbg(&av->isys->adev->dev,
+ 			"not pipe_av set, adding to incoming\n");
+ 		return;
+-- 
+2.39.0
+

--- a/intel-ipu6-dkms-git/PKGBUILD
+++ b/intel-ipu6-dkms-git/PKGBUILD
@@ -9,8 +9,12 @@ revision="913905fe01aa11219b121cf016a892c1654dec29"
 license=('unknown')
 depends=('dkms')
 makedepends=('git')
-source=("git+${url}.git#commit=${revision}")
-sha256sums=('SKIP')
+source=("git+${url}.git#commit=${revision}"
+	"0001-Fix-compilation-with-kernel-6.1.patch"
+	"0002-ipu-isys-queue-Fix-NULL-pointer-deref-with-kernels-6.patch")
+sha256sums=('SKIP'
+		'815345cde327e873f1ee569b476ecf78a00d0aeb737e84147bf5e7fcc01c00bb'
+		'ca4e48583457f20b32d483dff9e5d880027898efac4f9248e68ee8d92c395187')
 
 pkgver() {
     cd $_pkgname
@@ -19,6 +23,8 @@ pkgver() {
 
 prepare() {
     cd "$srcdir/$_pkgname"
+    patch -p1 < "${srcdir}/0001-Fix-compilation-with-kernel-6.1.patch"
+    patch -p1 < "${srcdir}/0002-ipu-isys-queue-Fix-NULL-pointer-deref-with-kernels-6.patch"
     git clone https://github.com/intel/ivsc-driver.git
     cp -r ivsc-driver/backport-include ivsc-driver/drivers ivsc-driver/include .
     rm -rf ivsc-driver

--- a/intel-ipu6-dkms-git/PKGBUILD
+++ b/intel-ipu6-dkms-git/PKGBUILD
@@ -1,14 +1,15 @@
 pkgname=intel-ipu6-dkms-git
 _pkgname=ipu6-drivers
-pkgver=r60.4ef83f208
+pkgver=r70.913905fe0
 pkgrel=1
 pkgdesc="Intel IPU6 camera drivers (DKMS)"
 arch=('any')
 url="https://github.com/intel/ipu6-drivers"
+revision="913905fe01aa11219b121cf016a892c1654dec29"
 license=('unknown')
 depends=('dkms')
 makedepends=('git')
-source=("git+${url}.git")
+source=("git+${url}.git#commit=${revision}")
 sha256sums=('SKIP')
 
 pkgver() {


### PR DESCRIPTION
Hi,
as stated in #1, while the installation script is executed successfully, the IPU6 DKMS driver fails to build on kernel >= 6.1.
Fixes have been submitted on Intel repository but seem to be stalled.
As discussed [here](https://github.com/stefanpartheym/archlinux-ipu6-webcam/issues/1#issuecomment-1368921922), I propose to integrate raw patches in your Archlinux packages while they are not merged on mainline.
The patches have been imported from the [submitted fixes author's fork](https://github.com/jwrdegoede/ipu6-drivers/tree/ipu6-kernel6.1-build-fix)
Once fixes are merged, on mainline, you would only have to : 
* remove the two patches by reverting the last commit
* bump package revision to fetch the latest driver from mainline

Would you consider taking this temporary fix ?
