### PR TITLE
added --workaround to install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # archlinux-ipu6-webcam
 
-This repository is supposed to provide an easy installation for the patched Intel IPU6 camera drivers. I tested the installation on kernel `6.0.2-arch1-1`.
+This repository is supposed to provide an easy installation for the patched Intel IPU6 camera drivers. Currently tested on `6.1.4-arch1-1` and `6.1.4-zen2-1-zen`
 
 All PKGBUILDs in this repository are taken from [this comment](https://bbs.archlinux.org/viewtopic.php?pid=2062371#p2062371) on the Archlinux forums.
 
@@ -18,19 +18,9 @@ Run shell script `uninstall.sh` to disable/stop services and uninstall all previ
 
 ## Make camera work in Chrome/Firefox and electron-based applications
 
-Unfortunately I couldn't figure out how to make the webcam available in web browsers and other electron-based applications out of the box.
+The camera should now work without any major issues in many applications (e.g. Chromium, OBS Studio) but it might not work correctly in some other applications (e.g. FireFox, Discord) due to the default NV12 format not being supported.
 
-However, [this post](https://stackoverflow.com/q/68433415) on stack overflow mentions the a workaround for this (see **Solution (long version)** for more details):
+This can be fixed by running the install.sh script with a `--workaround flag`, which will edit `/etc/systemd/system/v4l2-relayd.service.d/override.conf` to convert the camera output to the YUY2 format.
 
-```shell
-sudo modprobe -r v4l2loopback
-sudo modprobe v4l2loopback exclusive_caps=1
-```
+Please note that some applications (e.g. GNOME Cheese) will still very likely not work. This is due to Intel's driver just being low-quality. There is an [issue](https://github.com/stefanpartheym/archlinux-ipu6-webcam/issues/1) curently open for this.
 
-NOTE: You probably need to stop `v4l2-relayd.service` before you try to unload the `v4l2loopback` module, otherwise you'll receive the following error:
-
-```text
-modprobe: FATAL: Module v4l2loopback is in use.
-```
-
-Finally, you can test your setup [in your browser](https://webrtc.github.io/samples/src/content/devices/input-output/).

--- a/install.sh
+++ b/install.sh
@@ -64,7 +64,6 @@ sudo systemctl start v4l2-relayd.service && \
 
 
 if [ "$1" = "--workaround" ]; then
-  PATH="/etc/systemd/system/v4l2-relayd.service.d/"
   echo "# Creating /etc/systemd/system/v4l2-relayd.service.d/override.conf"
   sudo mkdir -p /etc/systemd/system/v4l2-relayd.service.d && \
   sudo echo -e "[Service]\nExecStart=\nExecStart=/bin/sh -c \'DEVICE=\$(grep -l -m1 -E \"^\${CARD_LABEL}\$\" /sys/devices/virtual/video4linux/*/name | cut -d/ -f6); exec /usr/bin/v4l2-relayd -i \"\${VIDEOSRC}\" \$\${SPLASHSRC:+-s \"\${SPLASHSRC}\"} -o \"appsrc name=appsrc caps=video/x-raw,format=\${FORMAT},width=\${WIDTH},height=\${HEIGHT},framerate=\${FRAMERATE} ! videoconvert ! video/x-raw,format=YUY2 ! v4l2sink name=v4l2sink device=/dev/\$\${DEVICE}\"\'" \

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 # Configure package manager here if necessary:
 if [ -f /bin/yay ]; then
   PKGMAN="yay -S --noconfirm"
-elif [ -f /bin/paru ]
+elif [ -f /bin/paru ]; then
   PKGMAN="paru -S --noconfirm"
 else
   echo "ERROR: Couldn't find a package manager, please configure it manually"

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,15 @@
 #!/bin/sh
 
 # Configure package manager here if necessary:
-PKGMAN="paru -S --noconfirm"
+if [ -f /bin/yay ]; then
+  PKGMAN="yay -S --noconfirm"
+elif [ -f /bin/paru ]
+  PKGMAN="paru -S --noconfirm"
+else
+  echo "ERROR: Couldn't find a package manager, please configure it manually"
+  exit 1
+fi
+
 # Configure makepkg here if necessary:
 MAKEPKG="makepkg -si --noconfirm"
 

--- a/install.sh
+++ b/install.sh
@@ -66,19 +66,19 @@ sudo systemctl start v4l2-relayd.service && \
 if [ "$1" = "--workaround" ]; then
   echo "# Creating /etc/systemd/system/v4l2-relayd.service.d/override.conf"
   sudo mkdir -p /etc/systemd/system/v4l2-relayd.service.d && \
-  sudo echo -e "[Service]\nExecStart=\nExecStart=/bin/sh -c \'DEVICE=\$(grep -l -m1 -E \"^\${CARD_LABEL}\$\" /sys/devices/virtual/video4linux/*/name | cut -d/ -f6); exec /usr/bin/v4l2-relayd -i \"\${VIDEOSRC}\" \$\${SPLASHSRC:+-s \"\${SPLASHSRC}\"} -o \"appsrc name=appsrc caps=video/x-raw,format=\${FORMAT},width=\${WIDTH},height=\${HEIGHT},framerate=\${FRAMERATE} ! videoconvert ! video/x-raw,format=YUY2 ! v4l2sink name=v4l2sink device=/dev/\$\${DEVICE}\"\'" \
-  sudo tee /etc/systemd/system/v4l2-relayd.service.d/override.conf && \
-  echo "=>SUCCESS" || \
-  error "Failed to write: /etc/systemd/system/v4l2-relayd.service.d/override.conf"
+  echo -e "[Service]\nExecStart=\nExecStart=/bin/sh -c 'DEVICE=\$(grep -l -m1 -E \"^\${CARD_LABEL}\$\" /sys/devices/virtual/video4linux/*/name | cut -d/ -f6); exec /usr/bin/v4l2-relayd -i \"\${VIDEOSRC}\" \$\${SPLASHSRC:+-s \"\${SPLASHSRC}\"} -o \"appsrc name=appsrc caps=video/x-raw,format=\${FORMAT},width=\${WIDTH},height=\${HEIGHT},framerate=\${FRAMERATE} ! videoconvert ! video/x-raw,format=YUY2 ! v4l2sink name=v4l2sink device=/dev/\$\${DEVICE}\"'" | \
+    sudo tee /etc/systemd/system/v4l2-relayd.service.d/override.conf >/dev/null && \
+    echo "=>SUCCESS" || \
+    error "Failed to write: /etc/systemd/system/v4l2-relayd.service.d/override.conf"
+  
+  echo "# Reloading systemd daemon"
+  sudo systemctl daemon-reload && \
+    echo "=> SUCCESS" || \
 
   echo "# Restart: v4l2-relayd.service"
   sudo systemctl restart v4l2-relayd.service && \
     echo "=> SUCCESS" || \
     error "Failed to restart: v4l2-relayd.service"
-  
-  echo "# Reloading systemd daemon"
-  sudo systemctl daemon-reload && \
-    echo "=> SUCCESS" || \
     error "Failed to reload systemctl daemon"
 fi
 

--- a/intel-ipu6ep-camera-hal-git/PKGBUILD
+++ b/intel-ipu6ep-camera-hal-git/PKGBUILD
@@ -1,7 +1,7 @@
 _ipu_ver=ipu6ep
 pkgname=intel-ipu6ep-camera-hal-git
 _pkgname=ipu6-camera-hal
-pkgver=r48.8bad42c
+pkgver=r52.3729289
 pkgrel=1
 pkgdesc="Intel IPU6 camera HAL (Alder Lake)"
 arch=('x86_64')

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,7 +1,14 @@
 #!/bin/sh
 
 # Configure package manager here if necessary:
-PKGMAN=yay
+if [ -f /bin/yay ]; then
+  PKGMAN=yay
+elif [ -f /bin/paru ]; then
+  PKGMAN=paru
+else
+  echo "ERROR: Couldn't find a package manager, please configure it manually"
+  exit 1
+fi
 
 sudo systemctl stop v4l2-relayd.service
 sudo systemctl disable v4l2-relayd.service
@@ -14,3 +21,7 @@ $PKGMAN -Rsn intel-ipu6ep-camera-bin
 $PKGMAN -Rsn intel-ipu6-dkms-git
 $PKGMAN -Rsn v4l2-relayd
 $PKGMAN -Rsn v4l2loopback-dkms-git
+
+if [ -d /etc/systemd/system/v4l2-relayd.service.d ]; then
+  sudo rm -rf /etc/systemd/system/v4l2-relayd.service.d/
+fi


### PR DESCRIPTION
This allows an easy implementation of what described [here](https://github.com/stefanpartheym/archlinux-ipu6-webcam/issues/1#issuecomment-1370005030).

Also, the `install.sh` and `uninstall.sh` scripts should now look for both yay and paru when looking for a package manager to use and print an error message if neither is found, asking the user to provide one manually.