### PR TITLE
readme: add test alternative with cheese

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Run shell script `install.sh` to install all necessary packages and enable/start
 
 ## Test
 
-Test your webcam by running script `test.sh`.
+Test your webcam by running script `test.sh`.  
+You can also use Cheese to test your video stack, a image/video capture software from Gnome. To do so, identify the name of the device exposed by your video stack with `v4l2-ctl --list-devices`, Then call Cheese : `sudo cheese -d <your_device_name>`  
+Example : `sudo cheese -d "Virtual Camera"`
 
 ## Uninstall
 


### PR DESCRIPTION
While `test.sh` does not currently work on my setup (which I still does not explain, since I have already observed it working on my machine), I managed to make [Cheese](https://doc.ubuntu-fr.org/cheese) work with my camera on my Dell XPS 13 Plus.
One needs to select appropriate video device in Cheese, BUT it does not work if we select the device in Cheese GUI.
It works when we provide the device directly on the command line, when starting cheese