### PR TITLE
test: select sink depending on running window manager

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
 
-sudo -E LANG=C gst-launch-1.0 icamerasrc ! autovideoconvert ! waylandsink
+# Configure sink depending on running window manager
+SINK=waylandsink
+pgrep -x Xorg && SINK=ximagesink
+
+sudo -E LANG=C gst-launch-1.0 icamerasrc ! autovideoconvert ! ${SINK}


### PR DESCRIPTION
I sometimes need to switch back to X window manager. In those cases, the test script fails since the sink is configured by default to open a Wayland window, with the gfollowing logs :
```
Setting pipeline to PAUSED ...
Failed to set pipeline to PAUSED.
Setting pipeline to NULL ...
Freeing pipeline ...
```
I propose to detect the running window manager to configure proper sink.
We _could_ hardcode `ximagesink` in all cases, since wayland bring retrocompatibilty for X applications thanks to `XWayland`, but I guess it is better to use the proper sink