### PR TITLE
Shell cleanup with bug fixes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,9 +24,11 @@ build_and_install() {
   $MAKEPKG
   local installation_state=$?
   popd || error "Unable to go back to working directory."
-  test $installation_state -eq 0 && \
-    echo "=> SUCCESS" || \
+  if [[ "${installation_state}" -eq 0 ]]; then
+    echo "=> SUCCESS"
+  else
     error "Failed to install: $1"
+  fi
 }
 
 # ------------------------------------------------------------------------------

--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 # Configure package manager here if necessary:
-if [ -f /bin/yay ]; then
+if [[ -x "$(command -v yay)" ]]; then
   PKGMAN="yay -S --noconfirm"
-elif [ -f /bin/paru ]; then
+elif [[ -x "$(command -v /bin/paru)" ]]; then
   PKGMAN="paru -S --noconfirm"
 else
-  echo "ERROR: Couldn't find a package manager, please configure it manually"
+  echo "ERROR: Couldn't find a package manager, please install either yay or paru"
   exit 1
 fi
 
@@ -14,20 +14,20 @@ fi
 MAKEPKG="makepkg -si --noconfirm"
 
 error() {
-  echo "ERROR: $1"
+  echo "ERROR: ${1}"
   exit 1
 }
 
 build_and_install() {
-  echo "# Build and install package: $1"
-  pushd "$1" || error "Not a directory: $1"
-  $MAKEPKG
-  local installation_state=$?
+  echo "# Build and install package: ${1}"
+  pushd "${1}" || error "Not a directory: ${1}"
+  eval "${MAKEPKG}"
+  local installation_state="${?}"
   popd || error "Unable to go back to working directory."
   if [[ "${installation_state}" -eq 0 ]]; then
     echo "=> SUCCESS"
   else
-    error "Failed to install: $1"
+    error "Failed to install: ${1}"
   fi
 }
 
@@ -35,16 +35,16 @@ build_and_install() {
 
 # Need to have the correct headers installed before proceding with DKMS
 if pacman -Qq linux >/dev/null 2>/dev/null; then
-  $PKGMAN --needed linux-headers
+  eval "${PKGMAN} --needed linux-headers"
 fi
 if pacman -Qq linux-lts >/dev/null 2>/dev/null; then
-  $PKGMAN --needed linux-lts-headers
+  eval "${PKGMAN} --needed linux-lts-headers"
 fi
 if pacman -Qq linux-zen >/dev/null 2>/dev/null; then
-  $PKGMAN --needed linux-zen-headers
+  eval "${PKGMAN} --needed linux-zen-headers"
 fi
 if pacman -Qq linux-hardened >/dev/null 2>/dev/null; then
-  $PKGMAN --needed linux-hardened-headers
+  eval "${PKGMAN} --needed linux-hardened-headers"
 fi
 
 # General dependencies to make the webcam work:
@@ -54,9 +54,11 @@ build_and_install "intel-ipu6-dkms-git"
 
 # Install dependency for intel-ipu6ep-camera-hal-git
 echo "# Install dependency for intel-ipu6ep-camera-hal-git"
-$PKGMAN intel-ipu6ep-camera-bin && \
-  echo "=> SUCCESS" || \
-  error "# Failed to install: intel-ipu6ep-camera-bin"
+  if eval "${PKGMAN} intel-ipu6ep-camera-bin"; then
+    echo "=> SUCCESS"
+  else
+    error "# Failed to install: intel-ipu6ep-camera-bin"
+  fi
 
 build_and_install "intel-ipu6ep-camera-hal-git"
 build_and_install "v4l2-looback-dkms-git"
@@ -64,36 +66,48 @@ build_and_install "v4l2-relayd"
 
 # Install general dependencies
 echo "# Install general dependencies"
-$PKGMAN $general_dependencies && \
-  echo "=> SUCCESS" || \
-  error "Failed to install: $general_dependencies"
+if eval "${PKGMAN} ${general_dependencies}"; then
+  echo "=> SUCCESS"
+else
+  error "Failed to install: ${general_dependencies}"
+fi
 
 echo "# Enable: v4l2-relayd.service"
-sudo systemctl enable v4l2-relayd.service && \
-  echo "=> SUCCESS" || \
+if sudo systemctl enable v4l2-relayd.service; then
+  echo "=> SUCCESS"
+else
   error "# Failed to enable: v4l2-relayd.service"
+fi
 echo "# Start: v4l2-relayd.service"
-sudo systemctl start v4l2-relayd.service && \
-  echo "=> SUCCESS" || \
+if sudo systemctl start v4l2-relayd.service; then
+  echo "=> SUCCESS"
+else
   error "Failed to start: v4l2-relayd.service"
+fi
 
 
-if [ "$1" = "--workaround" ]; then
+if [[ "${1}" == "--workaround" ]]; then
   echo "# Creating /etc/systemd/system/v4l2-relayd.service.d/override.conf"
   sudo mkdir -p /etc/systemd/system/v4l2-relayd.service.d && \
   echo -e "[Service]\nExecStart=\nExecStart=/bin/sh -c 'DEVICE=\$(grep -l -m1 -E \"^\${CARD_LABEL}\$\" /sys/devices/virtual/video4linux/*/name | cut -d/ -f6); exec /usr/bin/v4l2-relayd -i \"\${VIDEOSRC}\" \$\${SPLASHSRC:+-s \"\${SPLASHSRC}\"} -o \"appsrc name=appsrc caps=video/x-raw,format=\${FORMAT},width=\${WIDTH},height=\${HEIGHT},framerate=\${FRAMERATE} ! videoconvert ! video/x-raw,format=YUY2 ! v4l2sink name=v4l2sink device=/dev/\$\${DEVICE}\"'" | \
-    sudo tee /etc/systemd/system/v4l2-relayd.service.d/override.conf >/dev/null && \
-    echo "=> SUCCESS" || \
-    error "Failed to write: /etc/systemd/system/v4l2-relayd.service.d/override.conf"
+    if sudo tee /etc/systemd/system/v4l2-relayd.service.d/override.conf >/dev/null ; then
+      echo "=> SUCCESS"
+    else
+      error "Failed to write: /etc/systemd/system/v4l2-relayd.service.d/override.conf"
+    fi
 
   echo "# Reloading systemd daemon"
-  sudo systemctl daemon-reload && \
-    echo "=> SUCCESS" || \
+  if sudo systemctl daemon-reload; then
+    echo "=> SUCCESS"
+  else
     error "Failed to reload systemd daemon"
+  fi
 
   echo "# Restart: v4l2-relayd.service"
-  sudo systemctl restart v4l2-relayd.service && \
-    echo "=> SUCCESS" || \
+  if sudo systemctl restart v4l2-relayd.service; then
+    echo "=> SUCCESS"
+  else
     error "Failed to restart: v4l2-relayd.service"
+  fi
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Configure package manager here if necessary:
 if [ -f /bin/yay ]; then
@@ -19,12 +19,11 @@ error() {
 }
 
 build_and_install() {
-  test -d "$1" || error "Not a directory: $1"
   echo "# Build and install package: $1"
-  pushd "$1"
+  pushd "$1" || error "Not a directory: $1"
   $MAKEPKG
   local installation_state=$?
-  popd
+  popd || error "Unable to go back to working directory."
   test $installation_state -eq 0 && \
     echo "=> SUCCESS" || \
     error "Failed to install: $1"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,12 +1,12 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Configure package manager here if necessary:
-if [ -f /bin/yay ]; then
+if [[ -x "$(command -v yay)" ]]; then
   PKGMAN="yay -Rsn --noconfirm"
-elif [ -f /bin/paru ]; then
+elif [[ -x "$(command -v paru)" ]]; then
   PKGMAN="paru -Rsn --noconfirm"
 else
-  echo "ERROR: Couldn't find a package manager, please configure it manually"
+  echo "ERROR: Couldn't find a package manager, please install either yay or paru"
   exit 1
 fi
 
@@ -17,20 +17,20 @@ PKGSUFFIX=fix
 sudo systemctl stop v4l2-relayd.service
 sudo systemctl disable v4l2-relayd.service
 
-$PKGMAN intel-ivsc-driver-dkms-git
+eval "${PKGMAN} intel-ivsc-driver-dkms-git"
 # Not needed because it is uninstalled as a dependency of the previous package:
 #$PKGMAN intel-ivsc-firmware
 
-$PKGMAN icamerasrc-git
-$PKGMAN intel-ipu6ep-camera-hal-git-${PKGSUFFIX}
-$PKGMAN intel-ipu6ep-camera-bin
-$PKGMAN intel-ipu6-dkms-git-${PKGSUFFIX}
+eval "${PKGMAN} icamerasrc-git"
+eval "${PKGMAN} intel-ipu6ep-camera-hal-git-${PKGSUFFIX}"
+eval "${PKGMAN} intel-ipu6ep-camera-bin"
+eval "${PKGMAN} intel-ipu6-dkms-git-${PKGSUFFIX}"
 
-$PKGMAN v4l2-relayd
-$PKGMAN v4l2loopback-dkms-git-${PKGSUFFIX}
+eval "${PKGMAN} v4l2-relayd"
+eval "${PKGMAN} v4l2loopback-dkms-git-${PKGSUFFIX}"
 
-$PKGMAN gst-plugin-pipewire
+eval "${PKGMAN} gst-plugin-pipewire"
 
-if [ -d /etc/systemd/system/v4l2-relayd.service.d ]; then
+if [[ -d /etc/systemd/system/v4l2-relayd.service.d ]]; then
   sudo rm -rf /etc/systemd/system/v4l2-relayd.service.d/
 fi


### PR DESCRIPTION
I had some issues, especially with the `A && B || C` clauses in the script, because that situation does not work like an if-this-else clause.  So I replaced all those with if-this-else clauses.

I also went through the whole script and made it bash compliant, with the following reasoning:

pushd and popd are not built-in in all posix shell, it works in default arch because because in default /bin/sh is symlinked to bash. But it may not always be. So well there are benefits of having posix compliant scripts running in bash, the utility is limited. If the user has /bin/sh symlinked to dash or something else (this is a suggestion in the arch wiki to get posix shell scripts to run faster) then there is no pushd or popd.

Keep in mind I like pushd and popd, they are much better than using cd in shellscripts, and less messy than trying to make makepkg work in another directory. Maybe that would work, but pushd, and popd works exactly how you think it does.

Keep in mind I didn't touch test.sh in this PR, I don't see a reason to convert that to be bash compliant, but I will open another PR for the test.sh script for another reason.