### PR TITLE
Fixes and improve test.sh

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,11 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Configure sink depending on running window manager
-SINK=waylandsink
-pgrep -x Xorg >/dev/null && SINK=ximagesink
+case "${XDG_SESSION_TYPE}" in
+  wayland)
+    SINK=waylandsink ;;
+  x11)
+    SINK=ximagesink ;;
+esac
 
-sudo -E LANG=C gst-launch-1.0 icamerasrc ! video/x-raw,format=NV12,width=1280,height=720 ! videoconvert ! ${SINK}
+sudo -E LANG=C gst-launch-1.0 icamerasrc ! video/x-raw,format=NV12,width=1280,height=720 ! videoconvert ! "${SINK}"

--- a/test.sh
+++ b/test.sh
@@ -4,4 +4,4 @@
 SINK=waylandsink
 pgrep -x Xorg >/dev/null && SINK=ximagesink
 
-sudo -E LANG=C gst-launch-1.0 icamerasrc ! autovideoconvert ! ${SINK}
+sudo -E LANG=C gst-launch-1.0 icamerasrc ! video/x-raw,format=NV12,width=1280,height=720 ! videoconvert ! ${SINK}


### PR DESCRIPTION
For me auto-convert simply doesn't work. Back when I originally found this repo I saw the format string in the setting for v4l2-relayd, and I used that in this test script and it works for me. Please test the test first. I mean it should work since it's the same as in v4l2-relayd.

Also it didn't quite sit well with me to just test if X11 is running. What if the user has a nested x11 environment or runs X11 on another tty, or another monitor? So I switched it over to check $XDG_SESSION_TYPE instead. And what is faster to run between a case statement and if-elif, well case is almost twice as fast. case is not in all posix shells, so if the user has followed the suggestion in the arch wiki to switch /bin/sh to not be symlinked to bash then it will fail. So I converted the script over to bash instead of posix. :rofl: Sorry I know I mentioned in the other PR that I didn't see a need to do that, but case is better than if-elif so.