### PR TITLE
update driver to be able to compile on Linux 6.3

### DIFF
--- a/intel-ipu6-dkms-git/PKGBUILD
+++ b/intel-ipu6-dkms-git/PKGBUILD
@@ -1,11 +1,11 @@
 pkgname=intel-ipu6-dkms-git-fix
 _pkgname=ipu6-drivers
-pkgver=r86.7fdfb5eb2
+pkgver=r100.8c02a846d
 pkgrel=1
 pkgdesc="Intel IPU6 camera drivers (DKMS)"
 arch=('any')
 url="https://github.com/intel/ipu6-drivers"
-revision="7fdfb5eb220a01ef55aa09f8906613102da12cd0"
+revision="8c02a846d1afe0e108964a2d3db4acb175712da9"
 license=('unknown')
 depends=('dkms')
 makedepends=('git')

--- a/v4l2-looback-dkms-git/PKGBUILD
+++ b/v4l2-looback-dkms-git/PKGBUILD
@@ -1,6 +1,6 @@
 _pkgbase=v4l2loopback
 pkgname=${_pkgbase}-dkms-git-fix
-pkgver=r10.b37d72d
+pkgver=r10.f94def5
 pkgrel=1
 pkgdesc="v4l2-loopback device"
 url="https://github.com/umlaeute/v4l2loopback"


### PR DESCRIPTION
Note that currently https://aur.archlinux.org/packages/icamerasrc-git does not compile, and install.sh does try to update to this. This is not relevant for this commit. 

As a workaround, if you just want to test this Merge Request, If you have icamerasrc-git installed you can just temporarily remove that from general_dependencies in install.sh, or if you don't have it installed at all git clone https://aur.archlinux.org/icamerasrc-git.git cd into the dir, edit PKGBUILD and change the source array to be this

```bash
source=("git+${url}.git#commit=17841ab6249aaa69bd9b3959262bf182dee74111"
        "70-ipu6-psys.rules")
```
this just pulls down the older commit that works. Install the package using `makepkg -sic` and then install.sh should complete if you removed icamerasrc-git from the general_dependencies.

Writing this workaround here to help people, and fixing this is out of scope for this merge request.