### PR TITLE
Included the udev rule in the PKGBUILD, Added comments to PKGBUILDs, Changed README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Currently working on these devices:
 
 All PKGBUILDs in this repository are taken from [this comment](https://bbs.archlinux.org/viewtopic.php?pid=2062371#p2062371) on the Archlinux forums. From `v1.0.0` on, the PKGBUILDs are slightly modified to avoid conflicts with their AUR counter parts.
 
+Also added icamerasrc-git PKGBUILD that builds an older version because Intel's latest one broke. See https://github.com/intel/icamerasrc/pull/31#discussion_r1184456155
+
 ## Install
 
 Run shell script `install.sh` to install all necessary packages and enable/start services. Make sure to reboot after a successfull installation.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ This repository is supposed to provide an easy installation for the patched Inte
 - `6.1.9-arch1-1`
 - `6.3.7-arch1-1`
 
+Currently working on these devices:
+
+- `Lenovo ThinkPad X1 Carbon Gen 10` from https://github.com/stefanpartheym/archlinux-ipu6-webcam/pull/22#issuecomment-1587014417
+- `Dell XPS 13 Plus 9320` from https://github.com/stefanpartheym/archlinux-ipu6-webcam/pull/22#issue-1751399891
+
 All PKGBUILDs in this repository are taken from [this comment](https://bbs.archlinux.org/viewtopic.php?pid=2062371#p2062371) on the Archlinux forums. From `v1.0.0` on, the PKGBUILDs are slightly modified to avoid conflicts with their AUR counter parts.
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -66,5 +66,5 @@ Some AUR helpers will warn you of some packages installed by `install.sh` not be
 For example, if you're using paru, you might want to add the following to your `/etc/paru.conf` (or your user's config):
 
 ```
-NoWarn = intel-ipu6-dkms-git-fix  intel-ipu6ep-camera-hal-git-fix  v4l2-relayd  v4l2loopback-dkms-git-fix
+NoWarn = intel-ipu6-dkms-git-fix  intel-ipu6ep-camera-hal-git-fix  v4l2-relayd  v4l2loopback-dkms-git-fix icamerasrc-git-fix
 ```

--- a/icamerasrc-git/70-ipu6-psys.rules
+++ b/icamerasrc-git/70-ipu6-psys.rules
@@ -1,3 +1,0 @@
-# This rule makes the Intel IPU6 sensor accessible to members of group 'video',
-# allowing icamerasrc to be used as an unprivileged user.
-SUBSYSTEM=="intel-ipu6-psys",GROUP="video",MODE="0660"

--- a/icamerasrc-git/70-ipu6-psys.rules
+++ b/icamerasrc-git/70-ipu6-psys.rules
@@ -1,0 +1,3 @@
+# This rule makes the Intel IPU6 sensor accessible to members of group 'video',
+# allowing icamerasrc to be used as an unprivileged user.
+SUBSYSTEM=="intel-ipu6-psys",GROUP="video",MODE="0660"

--- a/icamerasrc-git/PKGBUILD
+++ b/icamerasrc-git/PKGBUILD
@@ -1,4 +1,6 @@
-# Maintainer: Karim Vergnes <me@thesola.io>
+# Fixed PKGBUILD from https://github.com/stefanpartheym/archlinux-ipu6-webcam
+# Uses earlier version of icamerasrc. See https://github.com/intel/icamerasrc/pull/31#discussion_r1184456155
+# Original PKGBUILD: https://aur.archlinux.org/packages/icamerasrc-git
 _pkgname=icamerasrc
 pkgname=icamerasrc-git-fix
 pkgver=r59.17841ab

--- a/icamerasrc-git/PKGBUILD
+++ b/icamerasrc-git/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Karim Vergnes <me@thesola.io>
 _pkgname=icamerasrc
-pkgname=${_pkgname}-git-fix
+pkgname=icamerasrc-git-fix
 pkgver=r59.17841ab
 pkgrel=1
 pkgdesc="Intel IPU6 camera source for GStreamer"
@@ -18,8 +18,7 @@ makedepends=('git'
 conflicts=('icamerasrc-git')
 source=("git+${url}.git#commit=17841ab6249aaa69bd9b3959262bf182dee74111"
         "70-ipu6-psys.rules")
-sha256sums=('SKIP'
-            '41f0406f4548f12dd3ec5c4c94c5f6f4590d48ac4c80623682f3d22622a8a9bd')
+sha256sums=('SKIP')
 
 pkgver() {
     cd $_pkgname
@@ -37,6 +36,10 @@ build() {
 package() {
     cd "$srcdir/$_pkgname"
     mkdir -p $pkgdir/usr/lib/udev/rules.d
+    printf '%s\n%s\n%s\n' \
+           '# This rule makes the Intel IPU6 sensor accessible to members of group "video",\n' \
+           '# allowing icamerasrc to be used as an unprivileged user.\n' \
+           'SUBSYSTEM=="intel-ipu6-psys",GROUP="video",MODE="0660"' \
+           > $pkgdir/usr/lib/udev/rules.d/70-ipu6-psys.rules
     make DESTDIR="$pkgdir" install
-    install -Dm644 $srcdir/70-ipu6-psys.rules $pkgdir/usr/lib/udev/rules.d
 }

--- a/icamerasrc-git/PKGBUILD
+++ b/icamerasrc-git/PKGBUILD
@@ -16,8 +16,7 @@ makedepends=('git'
              'make'
              'gcc')
 conflicts=('icamerasrc-git')
-source=("git+${url}.git#commit=17841ab6249aaa69bd9b3959262bf182dee74111"
-        "70-ipu6-psys.rules")
+source=("git+${url}.git#commit=17841ab6249aaa69bd9b3959262bf182dee74111")
 sha256sums=('SKIP')
 
 pkgver() {

--- a/intel-ipu6-dkms-git/PKGBUILD
+++ b/intel-ipu6-dkms-git/PKGBUILD
@@ -1,3 +1,7 @@
+# Fixed PKGBUILD from https://github.com/stefanpartheym/archlinux-ipu6-webcam
+# The ivsc-driver is now built together with the ipu6-driver, making the former conflict when installed
+# The original PKGBUILD now does the same, this might warrant removal later. Testing needed.
+# Original PKGBUILD: https://aur.archlinux.org/packages/intel-ipu6-dkms-git
 pkgname=intel-ipu6-dkms-git-fix
 _pkgname=ipu6-drivers
 pkgver=r100.8c02a846d

--- a/intel-ipu6ep-camera-hal-git/PKGBUILD
+++ b/intel-ipu6ep-camera-hal-git/PKGBUILD
@@ -1,3 +1,6 @@
+# Fixed PKGBUILD from https://github.com/stefanpartheym/archlinux-ipu6-webcam
+# Removed the udev rule that creates bunch of broken symlinks
+# Original PKGBUILD: https://aur.archlinux.org/packages/intel-ipu6ep-camera-hal-git
 _ipu_ver=ipu6ep
 pkgname=intel-ipu6ep-camera-hal-git-fix
 _pkgname=ipu6-camera-hal

--- a/v4l2-relayd/PKGBUILD
+++ b/v4l2-relayd/PKGBUILD
@@ -1,3 +1,5 @@
+# PKGBUILD from https://github.com/stefanpartheym/archlinux-ipu6-webcam
+# Builds the V4L2 Relay for the IPU6 devices. See https://code.launchpad.net/v4l2-relayd
 _pkgname=v4l2-relayd
 _host=git.launchpad.net
 pkgname=${_pkgname}

--- a/v4l2loopback-dkms-git/PKGBUILD
+++ b/v4l2loopback-dkms-git/PKGBUILD
@@ -1,3 +1,6 @@
+# Fixed PKGBUILD from https://github.com/stefanpartheym/archlinux-ipu6-webcam
+# Added required patches
+# Original PKGBUILD: https://aur.archlinux.org/packages/v4l2loopback-dkms-git
 _pkgbase=v4l2loopback
 pkgname=${_pkgbase}-dkms-git-fix
 pkgver=r10.f94def5


### PR DESCRIPTION
I forgor 💀

Supposed to be in https://github.com/stefanpartheym/archlinux-ipu6-webcam/pull/22 but was dropped by the .gitignore. Made the file printed by the PKGBUILD of icamerasrc-git-fix instead.

Edit: Removed the file and put it in the PKGBUILD. The new PKGBUILD should fix https://github.com/stefanpartheym/archlinux-ipu6-webcam/issues/24