### PR TITLE
Workaround for suspension while webacam in use

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ Since this is using `modprobe`, this will most likely not work on kernel lockdow
 
 If you want both workarounds, you can run `./install.sh -as`.
 
+## Suspend and hibernate while webcam is in use
+
+If the system suspends while the webcam is in use, the webcam may not work after resuming. To fix this, stopping the v4l2-relayd service before suspending is necessary. A script is provided by running `./install -d`. This script will be executed before suspending/hibernating and after resume.
+
+If you want all three workarounds, you can run `./install.sh -asd`.
+
 ## Tips and tricks
 
 ### Remove the warnings from an AUR helper

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,7 @@ MAKEPKG=(makepkg -si --noconfirm --needed)
 FLAG_YUY2_WA=false
 FLAG_S2DISK_HACK=false
 FLAG_EXPLICIT_WAYLAND=false
+FLAG_V4L2_SUSP=false
 FLAG_REBOOT_AFTER_INSTALL=false
 FLAG_QUIET_MODE=false
 
@@ -88,6 +89,10 @@ while getopts ":aswrqh" opt; do
       echo "Installing GST plugins for Wayland."
       FLAG_EXPLICIT_WAYLAND=true
       ;;
+    d)
+      echo "Suspension and hibernation workaround for V4L2 will be installed."
+      FLAG_V4L2_SUSP=true
+      ;;
     r)
       echo "System will reboot after installation."
       FLAG_REBOOT_AFTER_INSTALL=true
@@ -104,6 +109,7 @@ while getopts ":aswrqh" opt; do
       echo "  -w          Install GST plugins (bad) for Wayland. Only needed to specify if installing from the TTY."
       echo "              Normally, the script will check \$XDG_SESSION_TYPE to determine if Wayland is used."
       echo "              Right now, you are on '${XDG_SESSION_TYPE}'. If this is empty and you are going to use a Wayland DE, use this option."
+      echo "  -d          Install v4l2 workaround for suspension/hibernation."
       echo "  -r          Reboot after installation. Not recommended unless success is guaranteed."
       echo "  -q          Quiet mode by not printing builds and installs. Also not recommended. (Currently not working.)"
       echo "  -h          Show this help message."
@@ -145,6 +151,7 @@ if $FLAG_YUY2_WA; then
   sudo mkdir -p /etc/systemd/system/v4l2-relayd.service.d
   sudo cp -f workarounds/override.conf /etc/systemd/system/v4l2-relayd.service.d/override.conf
 fi
+$FLAG_V4L2_SUSP && sudo install -m 744 workarounds/v4l2-susp.sh /usr/lib/systemd/system-sleep/v4l2-susp.sh
 
 echo "# Enable: v4l2-relayd.service"
 if sudo systemctl enable v4l2-relayd.service; then

--- a/workarounds/v4l2-susp.sh
+++ b/workarounds/v4l2-susp.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Path: /usr/lib/systemd/system-sleep/v4l2-susp.sh
+# Stops and resumes the v4l2 relayd service, so that the webcam will work after resuming if it was in use
+# when the system was suspended.
+
+stage=$1
+op=$2
+
+if [ "pre" = "$stage" ]; then
+    systemctl stop v4l2-relayd.service
+elif [ "${1}" == "post" ]; then
+    systemctl start v4l2-relayd.service
+fi


### PR DESCRIPTION
If the webcam is in use when the system suspends, it may not work again after resuming. Stopping the v4l2 relayd service before suspension and starting it once the system is back on, seems to fix it.